### PR TITLE
Use npm trusted publishing (OIDC) for package releases

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -6,8 +6,16 @@ on:
 
 jobs:
   publish-npm:
-    uses: cabify/javascript-actions/.github/workflows/npm_publish.yml@main
-    with:
-      tag: ${{ contains(github.ref_name,'beta') && 'beta' || 'latest' }}
-    secrets:
-      token: ${{ secrets.NPM_TOKEN }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+      - run: yarn install
+      - run: yarn build
+      - run: npm publish --provenance --tag ${{ contains(github.ref_name,'beta') && 'beta' || 'latest' }}


### PR DESCRIPTION
## Summary

- Replace `NPM_TOKEN` secret with OIDC trusted publishing for npm
- Add `id-token: write` permission to enable provenance attestation
- Publish with `--provenance` flag for supply chain security
- No more token rotation needed every 90 days

## Setup done

Trusted publisher configured on npmjs.com for this repo/workflow (no environment).

## Test plan

- Merge this PR
- Create a new release to trigger the publish workflow
- Verify the package is published successfully on npm with provenance badge